### PR TITLE
Fix accessibility of constructor

### DIFF
--- a/memdothis-lib/include/memdothis.h
+++ b/memdothis-lib/include/memdothis.h
@@ -2,11 +2,12 @@
 
 class memdothis
 {
-	int x_;
-	int y_;
-	int z_;
+public:
+        memdothis(int x, int y, int z);
+        ~memdothis() = default;
 
-	memdothis(int x, int y, int z);
-	~memdothis() = default;
-
+private:
+        int x_;
+        int y_;
+        int z_;
 };


### PR DESCRIPTION
## Summary
- make `memdothis` constructor publicly accessible
- move data members to private section

## Testing
- `cmake ../memdothis-lib`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684993e66884832fad513e1b97621301